### PR TITLE
Load icon from entity

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Copy the single file `ha_wf_card.js` to the `www` folder of your Home Assistant 
 - `show_night`: Set to `true` to show night hours.
 - `default_source`: `forecastdata` (default) or `superforecastdata`.
 - `alert`: Alert configuration for highlighting certain wind conditions.
+- The card's icon is taken from the entity's `icon` attribute when available.
 
 ## License
 

--- a/ha_wf_card.js
+++ b/ha_wf_card.js
@@ -310,7 +310,7 @@ class HaWfCard extends HTMLElement {
       <ha-card>
           <div class="title-block">
             <div class="icon-title-block">
-              <ha-icon icon="mdi:windsock" id="refresh-icon" style="cursor:pointer" title="Refresh"></ha-icon>
+              <ha-icon id="refresh-icon" style="cursor:pointer" title="Refresh"></ha-icon>
             </div>
             <div class="text-title-block">
               <div class="card-title">${this.config.title || 'Kite Forecast'}</div>
@@ -367,6 +367,13 @@ class HaWfCard extends HTMLElement {
     const entity = this.config.entity;
     const stateObj = this._hass.states[entity];
     if (!stateObj) return;
+
+    const refreshIcon = this.querySelector('#refresh-icon');
+    if (refreshIcon) {
+      const icon = stateObj.attributes.icon || 'mdi:windsock';
+      refreshIcon.setAttribute('icon', icon);
+    }
+
     if (stateObj.state === this._lastState) return;
     this._lastState = stateObj.state;
     this._updateFromSelectedSource();


### PR DESCRIPTION
## Summary
- show the entity icon in the card header
- document that the header icon comes from the entity

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685a477579e88328b5f26613d7792d00