### PR TITLE
Fix superforecast day tab labels to use spot timezone

### DIFF
--- a/ha_wf_card.js
+++ b/ha_wf_card.js
@@ -635,11 +635,9 @@ class HaWfCard extends HTMLElement {
       this._activeDay = dayEntries[0][0];
     }
 
-    const baseDataDay = this._getBaseDataDay(sortedRows[0]);
-
-    datesRow.innerHTML = dayEntries.map(([day, rows], dayIndex) => {
+    datesRow.innerHTML = dayEntries.map(([day, rows]) => {
       const activeClass = day === this._activeDay ? 'active' : '';
-      const displayDay = this._formatDataDayLabel(this._addDays(baseDataDay, dayIndex));
+      const displayDay = this._formatDataDayLabel(rows[0]?.datetime);
 
       const windBars = rows.map(row => {
         const windSpeed = this._toFiniteNumber(row.wind_speed_kn);
@@ -847,42 +845,17 @@ class HaWfCard extends HTMLElement {
     return undefined;
   }
 
-  _formatDataDayLabel(date) {
-    return date.toLocaleDateString('en-GB', {
+  _formatDataDayLabel(value) {
+    const parsedDate = new Date(value);
+    if (isNaN(parsedDate.getTime())) {
+      return '-';
+    }
+    return parsedDate.toLocaleDateString('en-GB', {
       weekday: 'short',
       day: 'numeric',
       month: 'short',
-      timeZone: 'UTC',
+      ...this._getLocaleTimeZoneOptions(),
     });
-  }
-
-  _getBaseDataDay(firstRow) {
-    const rawDate = typeof firstRow?.datetime === 'string'
-      ? firstRow.datetime.slice(0, 10)
-      : '';
-    const match = rawDate.match(/^(\\d{4})-(\\d{2})-(\\d{2})$/);
-    if (match) {
-      const [, year, month, day] = match;
-      return new Date(Date.UTC(Number(year), Number(month) - 1, Number(day), 12));
-    }
-
-    const fallbackDate = new Date(firstRow?.datetime);
-    if (!isNaN(fallbackDate.getTime())) {
-      return new Date(Date.UTC(
-        fallbackDate.getUTCFullYear(),
-        fallbackDate.getUTCMonth(),
-        fallbackDate.getUTCDate(),
-        12,
-      ));
-    }
-
-    return new Date(Date.UTC(1970, 0, 1, 12));
-  }
-
-  _addDays(date, days) {
-    const nextDate = new Date(date.getTime());
-    nextDate.setUTCDate(nextDate.getUTCDate() + days);
-    return nextDate;
   }
 
   _getRowsPerDay(source) {


### PR DESCRIPTION
### Motivation
- The date tabs for the superforecast could start on yesterday while hourly rows were shown for today due to mixing UTC-normalized base-day logic with timezone-aware row rendering.
- The intent is for day tabs to match the displayed hourly times in the configured spot timezone so the UI is consistent.

### Description
- Updated day-tab label generation to derive the label from the tab's first row datetime (`rows[0]?.datetime`) instead of a UTC-normalized base day, and formatted it with the card timezone options via `_getLocaleTimeZoneOptions()` by changing `_formatDataDayLabel` to accept a datetime value.
- Removed the now-unused UTC base-day helper methods (`_getBaseDataDay` and `_addDays`) and eliminated the `dayIndex`-based offset logic when building `datesRow` in `ha_wf_card.js`.
- Kept existing timezone normalization and locale options logic (`_getSpotTimeZone`, `_normalizeTimeZone`, `_getLocaleTimeZoneOptions`) so labels are formatted consistently with the rest of the card.

### Testing
- Ran `node --check ha_wf_card.js` and it completed successfully with no syntax errors.
- Verified that the code paths that build `datesRow` and format labels now use `rows[0]?.datetime` and `_getLocaleTimeZoneOptions()` (static analysis / unit-free validation performed).
- No automated UI tests were available in this environment; changes are limited to `ha_wf_card.js` and are localized to date-label generation and helper removal.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee31be799c8328862a3da070ae1f8a)